### PR TITLE
Escape ampersand in feed URLs. Fixes #8

### DIFF
--- a/planet.py
+++ b/planet.py
@@ -150,7 +150,7 @@ def generar_rss(sql_conn):
             <link>{enlace}</link>
             <description>{titulo}</description>
             <pubDate>{fecha}</pubDate>
-            </item>""".format(blog=row[0], titulo=row[1], enlace=row[2], fecha=time.asctime(fecha)))
+            </item>""".format(blog=row[0], titulo=row[1], enlace=clean_html(row[2]), fecha=time.asctime(fecha)))
         if n > 10:
             break
     fout.write("</channel>\n</rss>")


### PR DESCRIPTION
```bash
$ curl https://victorhck.gitlab.io/planetalibre/feed.xml -o /tmp/feed.xml
$ xmllint --noout /tmp/feed.xml 2>&1 | head -n 1
feed.xml:40: parser error : EntityRef: expecting ';'
$ sed 's/&/&amp;/g' /tmp/feed.xml > /tmp/feed-test.xml
$ xmllint --noout /tmp/feed-test.xml
# Caused by: https://blog.bricogeek.com/noticias/feed/ (&utm --> &amp;utm)
```